### PR TITLE
Fix name of restart folder attribute in xmlParser

### DIFF
--- a/pyBadlands/forcing/xmlParser.py
+++ b/pyBadlands/forcing/xmlParser.py
@@ -50,7 +50,7 @@ class xmlParser:
         self.poroC = 0.47
 
         self.restart = False
-        self.rForlder = None
+        self.rfolder = None
         self.rStep = 0
         self.tStart = None
         self.tEnd = None

--- a/pyBadlands/forcing/xmlParser.py
+++ b/pyBadlands/forcing/xmlParser.py
@@ -51,7 +51,7 @@ class xmlParser:
 
         self.restart = False
         self.rfolder = None
-        self.rStep = 0
+        self.rstep = 0
         self.tStart = None
         self.tEnd = None
         self.tDisplay = None


### PR DESCRIPTION
That was causing a bug in a linkage restart...
R